### PR TITLE
add `package.json` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "dataset",
+  "version": "0.3.0",
+  "description": "Shim for DOM dataset",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/code42day/dataset.git"
+  },
+  "keywords": [
+    "dom",
+    "dataset"
+  ],
+  "author": "Damian Krzeminski <pirxpilot@code42day.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/code42day/dataset/issues"
+  },
+  "homepage": "https://github.com/code42day/dataset"
+}


### PR DESCRIPTION
I've published this module on npm under the `dataset` package name: https://www.npmjs.org/package/dataset

If you let me know your npm username I will add you as an owner as well.
If you merge this package.json file upstream then I won't need to maintain it in my fork.
Cheers!
