### PR TITLE
make compatible with node

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function toDashed(name) {
 
 var fn;
 
-if (document.head && document.head.dataset) {
+if (typeof document !== "undefined" && document.head && document.head.dataset) {
   fn = {
     set: function(node, attr, value) {
       node.dataset[attr] = value;


### PR DESCRIPTION
This fix prevents the module breaking when it is part of a codebase being run/tested using node. 