### PR TITLE
Add TypeScript typings

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,9 @@
 
+0.4.0 / 2018-01-12
+==================
+
+ * Add TypeScript typings and make a default export
+
 0.3.2 / 2017-02-19
 ==================
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,15 @@
+export interface IDataSetInstance {
+  del: (attribute: string) => IDataSetInstance;
+  get: (attribute: string) => IDataSetInstance;
+  set: (attribute: string, value: string) => IDataSetInstance;
+}
+
+export interface IDatasetStatic {
+  (node: HTMLElement): IDataSetInstance;
+  (node: HTMLElement, value: string): string;
+  (node: HTMLElement, attribute: string, value: string): undefined;
+}
+
+declare const dataset: IDatasetStatic;
+
+export default dataset;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 module.exports=dataset;
+// Allow use of default import syntax in TypeScript
+module.exports.default=dataset;
 
 /*global document*/
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "dataset",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Shim for DOM dataset",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This adds [TypeScript](typescriptlang.org/) typings and a default export so it's easier to import it from it.

Eg:

```js
import dataset from 'dataset';
```